### PR TITLE
Calculate and set downtime to a normalization hour

### DIFF
--- a/nagios.coffee
+++ b/nagios.coffee
@@ -21,13 +21,21 @@
 
 nagios_url = process.env.HUBOT_NAGIOS_URL
 process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
+normalize_parsetime_days_to_hour = 12
 
 module.exports = (robot) ->
   # d=days h=hours m=min default m
   parsetime = (time) =>
     lastchar = time[-1..]
     if lastchar == 'd'
-      return time[..-2] * 60 * 24
+      # Calculate and substract an offset from the normalization hour set above. Allow setting downtime
+      # at 2am that will expire at 12pm instead of 2am the following interval.
+      if normalize_parsetime_days_to_hour >= 0
+        d = new Date
+        offset = -(d.getHours() - normalize_parsetime_days_to_hour) - (d.getMinutes() / 60)
+      else
+        offset = 0
+      return (time[..-2] * 60 * 24) + (offset * 60)
     else if lastchar == 'h'
       return time[..-2] * 60
     else if lastchar == 'm'

--- a/nagios.coffee
+++ b/nagios.coffee
@@ -28,7 +28,7 @@ module.exports = (robot) ->
   parsetime = (time) =>
     lastchar = time[-1..]
     if lastchar == 'd'
-      # Calculate and substract an offset from the normalization hour set above. Allow setting downtime
+      # Calculate and subtract an offset from the normalization hour set above. Allow setting downtime
       # at 2am that will expire at 12pm instead of 2am the following interval.
       if normalize_parsetime_days_to_hour >= 0
         d = new Date


### PR DESCRIPTION
This resolves issue #4. When you specify downtime at 2am for 1 day, the downtime will expire at noon on the following day rather than 2am on the following day.
